### PR TITLE
Shebang fix

### DIFF
--- a/game.py
+++ b/game.py
@@ -1,4 +1,3 @@
-#!usr/bin/python
 # -*- coding:utf-8 -*-
 
 from piece import Piece

--- a/piece.py
+++ b/piece.py
@@ -1,4 +1,3 @@
-#!usr/bin/python
 # -*- coding:utf-8 -*-
 
 

--- a/shakki.py
+++ b/shakki.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding:utf-8 -*-
 
 from ui import UI

--- a/shakki.py
+++ b/shakki.py
@@ -1,4 +1,4 @@
-#!usr/bin/python
+#!/usr/bin/python
 # -*- coding:utf-8 -*-
 
 from ui import UI


### PR DESCRIPTION
The current shebang `#!usr/bin/python` in the scripts does not work, since it is missing the initial slash. This PR fixes this by using shebang `#!/usr/bin/env python` that also works if python is not in /usr/bin/python, which could happen if python is run using a virtual environment.

The PR also adds the execution permissions to shakki.py, making it possible to run directly with command `./shakki.py`. The shebangs from the other scripts that are not meant to be run directly are removed.
