### PR TITLE
UI improvement

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -31,6 +31,11 @@ class UI():
             print x[i:i+1],
         print '\033[10A'
 
+    def clear_workspace(self):
+        for i in range(11):
+            print '\r\033[K'
+        print '\033[10A'
+
     def clear_lines(self):
         print '\033[2A\r\033[K\n\033[K'
     
@@ -75,8 +80,7 @@ class UI():
             self.show_message(ex)
 
     def start(self):
-        print ''
-        print ''
+        self.clear_workspace()
         while True:
             self.print_board()
             cmd = raw_input()

--- a/ui.py
+++ b/ui.py
@@ -31,11 +31,14 @@ class UI():
             print x[i:i+1],
         print '\033[10A'
 
-    def clear_line(self):
-        print '\033[1A\r      '
+    def clear_lines(self):
+        print '\033[2A\r\033[K\n\033[K'
+    
+    def show_message(self, msg):
+        print '\033[2A\r{}\n'.format(msg)
 
     def user_input(self, cmd):
-        self.clear_line()
+        self.clear_lines()
         if 'hax' in cmd:
             if not testmode:
                 return
@@ -52,7 +55,7 @@ class UI():
             try:
                 self.game.castle(king_side)
             except IllegalMoveError as ex:
-                print ex
+                self.show_message(ex)
             return
         
         if ' ' not in cmd:
@@ -69,9 +72,10 @@ class UI():
         try:
             self.game.move(orig, dest)
         except IllegalMoveError as ex:
-            print ex
+            self.show_message(ex)
 
     def start(self):
+        print ''
         print ''
         while True:
             self.print_board()


### PR DESCRIPTION
Currently the game does not clear the lines it uses, meaning that if a new game is started after finishing a game, the new game is drawn over the previous game state. Furthermore, the error messages are written on the same line as the commands, meaning that the following command is written over the previous error message.

This PR fixes the above issues by clearing the game area in the start and using a separate line above the command line for error messages. The correct terminal escape code `\033[K` is used for clearing lines, instead of using a fixed number of spaces (which does not work for clearing long error messages).